### PR TITLE
use rpm builder as a source of openapi documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -114,7 +114,7 @@ module.exports = {
         specs: [{
           id: 'api-data-collection',
           route: 'api-data-collection',
-          spec: 'api-data-collection/documentations-huma.json',
+          spec: 'https://workspace-gcp-uk.api.huma.com/openapi.json',
         }]
       }
     ]


### PR DESCRIPTION
This PR uses the builder version of the RPM project as the source for the `openapi.json` file. The `/api-data-collection` path now refers to the RPM Builder documentation.